### PR TITLE
Fix tests

### DIFF
--- a/test/Controller/TestAsset/vendor/bin/zfdeploy.php
+++ b/test/Controller/TestAsset/vendor/bin/zfdeploy.php
@@ -1,4 +1,4 @@
 <?php
-// Mock laminasdeloy.php
+// Mock zfdeploy.php
 $package = $argv[2];
 file_put_contents($package, 'test');


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Reverts change to mock zfdeploy in laminas migration. As https://github.com/zfcampus/zf-deploy suggests there is no replacement, some refactoring to remove the need for this package might be preferable in the future