### PR TITLE
Fixes Accept header to allow legacy and laminas-api-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,19 +231,19 @@ overrides of individual values in it. All overrides are written to a single
 file, `config/autoload/development.php`; you can override that location in your
 configuration via the `api-tools-configuration.config-file` key.
 
-- `Accept`: `application/json`, `application/vnd.laminascampus.v1.config+json`
+- `Accept`: `application/json`, `application/vnd.laminas-api-tools.v1.config+json`
 
   `application/json` will deliver representations as a flat array of key/value pairs,
   with the keys being dot-separated values, just as you would find in INI.
 
-  `application/vnd.laminascampus.v1.config+json` will deliver the configuration as a tree.
+  `application/vnd.laminas-api-tools.v1.config+json` will deliver the configuration as a tree.
 
-- `Content-Type`: `application/json`, `application/vnd.laminascampus.v1.config+json`
+- `Content-Type`: `application/json`, `application/vnd.laminas-api-tools.v1.config+json`
 
   `application/json` indicates you are sending key/value pairs, with keys being dot-separated
   values, as you would find in INI files.
 
-  `application/vnd.laminascampus.v1.config+json` indicates you are sending a nested array/object of
+  `application/vnd.laminas-api-tools.v1.config+json` indicates you are sending a nested array/object of
   configuration.
 
 - Methods: `GET`, `PATCH`

--- a/src/Controller/AbstractConfigController.php
+++ b/src/Controller/AbstractConfigController.php
@@ -114,7 +114,8 @@ abstract class AbstractConfigController extends AbstractActionController
         $accept = strtolower(trim($accept));
         switch ($accept) {
             case 'application/json':
-            case 'application/vnd.laminascampus.v1.config+json':
+            case 'application/vnd.laminas-api-tools.v1.config+json':
+            case 'application/vnd.zfcampus.v1.config+json': // @todo Remove Legacy Zend Framework accept header
                 return $accept;
             default:
                 return 'application/json';

--- a/src/Controller/AbstractConfigController.php
+++ b/src/Controller/AbstractConfigController.php
@@ -115,7 +115,9 @@ abstract class AbstractConfigController extends AbstractActionController
         switch ($accept) {
             case 'application/json':
             case 'application/vnd.laminas-api-tools.v1.config+json':
-            case 'application/vnd.zfcampus.v1.config+json': // @todo Remove Legacy Zend Framework accept header
+            // @todo Remove Legacy Zend Framework accept header
+            case 'application/vnd.laminascampus.v1.config+json':
+            case 'application/vnd.zfcampus.v1.config+json':
                 return $accept;
             default:
                 return 'application/json';

--- a/test/Controller/ConfigControllerTest.php
+++ b/test/Controller/ConfigControllerTest.php
@@ -61,7 +61,7 @@ class ConfigControllerTest extends TestCase
         $this->assertEquals(405, $apiProblem->status);
     }
 
-    public function testProcessGetRequestWithLaminasCampusMediaTypeReturnsFullConfiguration()
+    public function testProcessGetRequestWithLaminasApiToolsMediaTypeReturnsFullConfiguration()
     {
         $config = [
             'foo' => 'FOO',
@@ -76,8 +76,8 @@ class ConfigControllerTest extends TestCase
 
         $request = new Request();
         $request->setMethod('get');
-        $request->getHeaders()->addHeaderLine('Content-Type', 'application/vnd.laminascampus.v1.config+json');
-        $request->getHeaders()->addHeaderLine('Accept', 'application/vnd.laminascampus.v1.config+json');
+        $request->getHeaders()->addHeaderLine('Content-Type', 'application/vnd.laminas-api-tools.v1.config+json');
+        $request->getHeaders()->addHeaderLine('Accept', 'application/vnd.laminas-api-tools.v1.config+json');
         $controller->setRequest($request);
 
         $result = $controller->processAction();
@@ -114,7 +114,7 @@ class ConfigControllerTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testProcessPatchRequestWithLaminasCampusMediaTypeReturnsUpdatedConfigurationKeys()
+    public function testProcessPatchRequestWithLaminasApiToolsMediaTypeReturnsUpdatedConfigurationKeys()
     {
         $config = [
             'foo' => 'FOO',
@@ -135,8 +135,8 @@ class ConfigControllerTest extends TestCase
             ],
             'baz' => 'UPDATED',
         ]));
-        $request->getHeaders()->addHeaderLine('Content-Type', 'application/vnd.laminascampus.v1.config+json');
-        $request->getHeaders()->addHeaderLine('Accept', 'application/vnd.laminascampus.v1.config+json');
+        $request->getHeaders()->addHeaderLine('Content-Type', 'application/vnd.laminas-api-tools.v1.config+json');
+        $request->getHeaders()->addHeaderLine('Accept', 'application/vnd.laminas-api-tools.v1.config+json');
         $controller->setRequest($request);
 
         $result = $controller->processAction();


### PR DESCRIPTION


|    Q          |   A
|-------------- | ------
| Bugfix        | yes/no

### Description

On migration accept/content-type header has been changed to invalid value. Now we accepts both:
- new: `application/vnd.laminas-api-tools.v1.config+json`
- legacy: `application/vnd.zfcampus.v1.config+json`



<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
