### PR TITLE
#75 fixed broken validation of page_size parameter

### DIFF
--- a/src/InputFilter/RestService/PatchInputFilter.php
+++ b/src/InputFilter/RestService/PatchInputFilter.php
@@ -75,7 +75,7 @@ class PatchInputFilter extends PostInputFilter
             'continue_if_empty' => true,
             'validators'        => [
                 new CallbackValidator(function ($value) {
-                    if (is_numeric($value) && intval($value) !== $value) {
+                    if (!is_numeric($value) || intval($value) != $value) {
                         return false;
                     }
 

--- a/src/InputFilter/RestService/PatchInputFilter.php
+++ b/src/InputFilter/RestService/PatchInputFilter.php
@@ -75,7 +75,7 @@ class PatchInputFilter extends PostInputFilter
             'continue_if_empty' => true,
             'validators'        => [
                 new CallbackValidator(function ($value) {
-                    if (!is_numeric($value) || intval($value) != $value) {
+                    if (!is_numeric($value) || ((string)$value) !== (string)(int)$value) {
                         return false;
                     }
 

--- a/src/InputFilter/RestService/PatchInputFilter.php
+++ b/src/InputFilter/RestService/PatchInputFilter.php
@@ -75,6 +75,7 @@ class PatchInputFilter extends PostInputFilter
             'continue_if_empty' => true,
             'validators'        => [
                 new CallbackValidator(function ($value) {
+                    // Make sure that the value is a numeric int or string and that there are no decimals
                     if (! is_numeric($value) || ((string) $value) !== (string) (int) $value) {
                         return false;
                     }

--- a/src/InputFilter/RestService/PatchInputFilter.php
+++ b/src/InputFilter/RestService/PatchInputFilter.php
@@ -75,7 +75,7 @@ class PatchInputFilter extends PostInputFilter
             'continue_if_empty' => true,
             'validators'        => [
                 new CallbackValidator(function ($value) {
-                    if (!is_numeric($value) || ((string)$value) !== (string)(int)$value) {
+                    if (! is_numeric($value) || ((string) $value) !== (string) (int) $value) {
                         return false;
                     }
 

--- a/test/InputFilter/RestService/PatchInputFilterTest.php
+++ b/test/InputFilter/RestService/PatchInputFilterTest.php
@@ -55,7 +55,7 @@ class PatchInputFilterTest extends TestCase
                     ],
                     'entity_identifier_name'     => 'id',
                     'hydrator_name'              => ArraySerializableHydrator::class,
-                    'page_size'                  => 25,
+                    'page_size'                  => "25",
                     'page_size_param'            => null,
                     'resource_class'             => 'Foo_Bar\\V1\\Rest\\Baz_Bat\\Baz_BatResource',
                     'route_identifier_name'      => 'foo_bar_id',

--- a/test/InputFilter/RestService/PatchInputFilterTest.php
+++ b/test/InputFilter/RestService/PatchInputFilterTest.php
@@ -35,7 +35,7 @@ class PatchInputFilterTest extends TestCase
             'page_size-string'           => ['25'],
             'page_size-string-negative'  => ['-1'],
             'page_size-integer'          => [25],
-            'page_size-integer-negative' => [-1]
+            'page_size-integer-negative' => [-1],
         ];
     }
 

--- a/test/InputFilter/RestService/PatchInputFilterTest.php
+++ b/test/InputFilter/RestService/PatchInputFilterTest.php
@@ -207,6 +207,7 @@ class PatchInputFilterTest extends TestCase
         return [
             'page_size-string-float'           => ['25.5'],
             'page_size-string-wrong-negative'  => ['-2'],
+            'page_size-string-nan'             => ['invalid'],
             'page_size-float'                  => [25.5],
             'page_size-integer-wrong-negative' => [-2],
         ];

--- a/test/InputFilter/RestService/PatchInputFilterTest.php
+++ b/test/InputFilter/RestService/PatchInputFilterTest.php
@@ -193,11 +193,7 @@ class PatchInputFilterTest extends TestCase
         self::assertEquals($expectedInvalidKeys, $testKeys);
     }
 
-    /**
-     * @psalm-return array<string, array{
-     *     string|integer|float
-     * }>
-     */
+    /** @psalm-return array<string, array{0: string|int|float}> */
     public function dataProviderInvalidPageSizes(): array
     {
         return [

--- a/test/InputFilter/RestService/PatchInputFilterTest.php
+++ b/test/InputFilter/RestService/PatchInputFilterTest.php
@@ -130,7 +130,7 @@ class PatchInputFilterTest extends TestCase
 
     /**
      * @dataProvider dataProviderIsValidTrue
-     * @param mixed $pageSize
+     * @param string|int $pageSize
      */
     public function testIsValidTrue($pageSize): void
     {

--- a/test/InputFilter/RestService/PatchInputFilterTest.php
+++ b/test/InputFilter/RestService/PatchInputFilterTest.php
@@ -24,11 +24,7 @@ class PatchInputFilterTest extends TestCase
         ]);
     }
 
-    /**
-     * @psalm-return array<string, array{
-     *     string|integer
-     * }>
-     */
+    /** @psalm-return array<string, array{0: string|int}> */
     public function dataProviderIsValidTrue(): array
     {
         return [

--- a/test/InputFilter/RestService/PatchInputFilterTest.php
+++ b/test/InputFilter/RestService/PatchInputFilterTest.php
@@ -24,82 +24,18 @@ class PatchInputFilterTest extends TestCase
         ]);
     }
 
-    /** @psalm-return array<string, array{0: array<string, mixed>}> */
+    /**
+     * @psalm-return array<string, array{
+     *     string|integer
+     * }>
+     */
     public function dataProviderIsValidTrue(): array
     {
         return [
-            'all-inputs-present' => [
-                [
-                    'accept_whitelist'           => [
-                        0 => 'application/vnd.foo_bar.v1+json',
-                        1 => 'application/hal+json',
-                        2 => 'application/json',
-                    ],
-                    'collection_class'           => Paginator::class,
-                    'collection_http_methods'    => [
-                        0 => 'GET',
-                        1 => 'POST',
-                    ],
-                    'collection_name'            => 'foo_bar',
-                    'collection_query_whitelist' => [],
-                    'content_type_whitelist'     => [
-                        0 => 'application/vnd.foo_bar.v1+json',
-                        1 => 'application/json',
-                    ],
-                    'entity_class'               => 'StdClass',
-                    'entity_http_methods'        => [
-                        0 => 'GET',
-                        1 => 'PATCH',
-                        2 => 'PUT',
-                        3 => 'DELETE',
-                    ],
-                    'entity_identifier_name'     => 'id',
-                    'hydrator_name'              => ArraySerializableHydrator::class,
-                    'page_size'                  => "25",
-                    'page_size_param'            => null,
-                    'resource_class'             => 'Foo_Bar\\V1\\Rest\\Baz_Bat\\Baz_BatResource',
-                    'route_identifier_name'      => 'foo_bar_id',
-                    'route_match'                => '/foo_bar[/:foo_bar_id]',
-                    'selector'                   => 'HalJson',
-                    'service_name'               => 'Baz_Bat',
-                ],
-            ],
-            'page_size-negative' => [
-                [
-                    'accept_whitelist'           => [
-                        0 => 'application/vnd.foo_bar.v1+json',
-                        1 => 'application/hal+json',
-                        2 => 'application/json',
-                    ],
-                    'collection_class'           => Paginator::class,
-                    'collection_http_methods'    => [
-                        0 => 'GET',
-                        1 => 'POST',
-                    ],
-                    'collection_name'            => 'foo_bar',
-                    'collection_query_whitelist' => [],
-                    'content_type_whitelist'     => [
-                        0 => 'application/vnd.foo_bar.v1+json',
-                        1 => 'application/json',
-                    ],
-                    'entity_class'               => 'StdClass',
-                    'entity_http_methods'        => [
-                        0 => 'GET',
-                        1 => 'PATCH',
-                        2 => 'PUT',
-                        3 => 'DELETE',
-                    ],
-                    'entity_identifier_name'     => 'id',
-                    'hydrator_name'              => ArraySerializableHydrator::class,
-                    'page_size'                  => -1,
-                    'page_size_param'            => null,
-                    'resource_class'             => 'Foo_Bar\\V1\\Rest\\Baz_Bat\\Baz_BatResource',
-                    'route_identifier_name'      => 'foo_bar_id',
-                    'route_match'                => '/foo_bar[/:foo_bar_id]',
-                    'selector'                   => 'HalJson',
-                    'service_name'               => 'Baz_Bat',
-                ],
-            ],
+            'page_size-string'           => ['25'],
+            'page_size-string-negative'  => ['-1'],
+            'page_size-integer'          => [1],
+            'page_size-integer-negative' => [-1]
         ];
     }
 
@@ -198,10 +134,46 @@ class PatchInputFilterTest extends TestCase
 
     /**
      * @dataProvider dataProviderIsValidTrue
-     * @param array<string, mixed> $data
+     * @param mixed $pageSize
      */
-    public function testIsValidTrue(array $data): void
+    public function testIsValidTrue($pageSize): void
     {
+        $data =
+            [
+                'accept_whitelist'           => [
+                    0 => 'application/vnd.foo_bar.v1+json',
+                    1 => 'application/hal+json',
+                    2 => 'application/json',
+                ],
+                'collection_class'           => Paginator::class,
+                'collection_http_methods'    => [
+                    0 => 'GET',
+                    1 => 'POST',
+                ],
+                'collection_name'            => 'foo_bar',
+                'collection_query_whitelist' => [],
+                'content_type_whitelist'     => [
+                    0 => 'application/vnd.foo_bar.v1+json',
+                    1 => 'application/json',
+                ],
+                'entity_class'               => 'StdClass',
+                'entity_http_methods'        => [
+                    0 => 'GET',
+                    1 => 'PATCH',
+                    2 => 'PUT',
+                    3 => 'DELETE',
+                ],
+                'entity_identifier_name'     => 'id',
+                'hydrator_name'              => ArraySerializableHydrator::class,
+                'page_size'                  => $pageSize,
+                'page_size_param'            => null,
+                'resource_class'             => 'Foo_Bar\\V1\\Rest\\Baz_Bat\\Baz_BatResource',
+                'route_identifier_name'      => 'foo_bar_id',
+                'route_match'                => '/foo_bar[/:foo_bar_id]',
+                'selector'                   => 'HalJson',
+                'service_name'               => 'Baz_Bat',
+            ];
+
         $filter = $this->getInputFilter();
         $filter->setData($data);
         self::assertTrue($filter->isValid(), var_export($filter->getMessages(), true));
@@ -223,5 +195,67 @@ class PatchInputFilterTest extends TestCase
         sort($expectedInvalidKeys);
         sort($testKeys);
         self::assertEquals($expectedInvalidKeys, $testKeys);
+    }
+
+    /**
+     * @psalm-return array<string, array{
+     *     string|integer|float
+     * }>
+     */
+    public function dataProviderInvalidPageSizes(): array
+    {
+        return [
+            'page_size-string-float'           => ['25.5'],
+            'page_size-string-wrong-negative'  => ['-2'],
+            'page_size-float'                  => [25.5],
+            'page_size-integer-wrong-negative' => [-2],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderInvalidPageSizes
+     * @param mixed $pageSize
+     */
+    public function testInvalidPageSizes($pageSize): void
+    {
+        $data =
+            [
+                'accept_whitelist'           => [
+                    0 => 'application/vnd.foo_bar.v1+json',
+                    1 => 'application/hal+json',
+                    2 => 'application/json',
+                ],
+                'collection_class'           => Paginator::class,
+                'collection_http_methods'    => [
+                    0 => 'GET',
+                    1 => 'POST',
+                ],
+                'collection_name'            => 'foo_bar',
+                'collection_query_whitelist' => [],
+                'content_type_whitelist'     => [
+                    0 => 'application/vnd.foo_bar.v1+json',
+                    1 => 'application/json',
+                ],
+                'entity_class'               => 'StdClass',
+                'entity_http_methods'        => [
+                    0 => 'GET',
+                    1 => 'PATCH',
+                    2 => 'PUT',
+                    3 => 'DELETE',
+                ],
+                'entity_identifier_name'     => 'id',
+                'hydrator_name'              => ArraySerializableHydrator::class,
+                'page_size'                  => $pageSize,
+                'page_size_param'            => null,
+                'resource_class'             => 'Foo_Bar\\V1\\Rest\\Baz_Bat\\Baz_BatResource',
+                'route_identifier_name'      => 'foo_bar_id',
+                'route_match'                => '/foo_bar[/:foo_bar_id]',
+                'selector'                   => 'HalJson',
+                'service_name'               => 'Baz_Bat',
+            ];
+
+        $filter = $this->getInputFilter();
+        $filter->setData($data);
+        self::assertFalse($filter->isValid(), var_export($filter->getMessages(), true));
     }
 }

--- a/test/InputFilter/RestService/PatchInputFilterTest.php
+++ b/test/InputFilter/RestService/PatchInputFilterTest.php
@@ -34,7 +34,7 @@ class PatchInputFilterTest extends TestCase
         return [
             'page_size-string'           => ['25'],
             'page_size-string-negative'  => ['-1'],
-            'page_size-integer'          => [1],
+            'page_size-integer'          => [25],
             'page_size-integer-negative' => [-1]
         ];
     }

--- a/test/InputFilter/RestService/PatchInputFilterTest.php
+++ b/test/InputFilter/RestService/PatchInputFilterTest.php
@@ -207,7 +207,7 @@ class PatchInputFilterTest extends TestCase
 
     /**
      * @dataProvider dataProviderInvalidPageSizes
-     * @param mixed $pageSize
+     * @param string|int|float $pageSize
      */
     public function testInvalidPageSizes($pageSize): void
     {


### PR DESCRIPTION
Signed-off-by: Pascal Paulis <ppaulis@gmail.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This fixes the bug described in #75 .

The concerned part is:

if (is_numeric($value) && intval($value) !== $value) {
    return false;
}

This validation makes no sense the way it is, because the GUI sends strings like "50", and in this case `intval($value) !== $value` always evaluates to true, due to the strict comparison. Instead, the validation should be :
```
if (!is_numeric($value) || intval($value) != $value) {
    return false;
}
```
as proposed in this PR.

The Unit Test in this case was incorrect because it only tested on integers.