### PR TITLE
Expanded `AbstractResourceListener#fetchAll()` child class implementations to allow `Laminas\Stdlib\Parameters` as parameter type

### DIFF
--- a/view/code-connected/rest-resource.phtml
+++ b/view/code-connected/rest-resource.phtml
@@ -2,6 +2,7 @@ namespace <?= $module ?>\V<?= $version ?>\Rest\<?= $resource ?>;
 
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Laminas\ApiTools\Rest\AbstractResourceListener;
+use Laminas\Stdlib\Parameters;
 
 class <?= $classname ?> extends AbstractResourceListener
 {
@@ -52,7 +53,7 @@ class <?= $classname ?> extends AbstractResourceListener
     /**
      * Fetch all or a subset of resources
      *
-     * @param  array $params
+     * @param  array|Parameters $params
      * @return ApiProblem|mixed
      */
     public function fetchAll($params = [])


### PR DESCRIPTION
Signed-off-by: Pascal Paulis <ppaulis@gmail.com>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Issue described in #82 

This PR fixes the missing parameter type in the rest-resource template that has been added to the parent method in https://github.com/laminas-api-tools/api-tools-rest/pull/28.

Fixes #82 