### PR TITLE
Use laminas-api-tools/api-tools-admin-ui v2, to prevent erroneous usage of the (recently removed) deploy component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "laminas-api-tools/api-tools": "^1.4",
-        "laminas-api-tools/api-tools-admin-ui": "^1.3.9",
+        "laminas-api-tools/api-tools-admin-ui": "^2.0",
         "laminas-api-tools/api-tools-api-problem": "^1.3",
         "laminas-api-tools/api-tools-configuration": "^1.3.3",
         "laminas-api-tools/api-tools-content-negotiation": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "afe9202abbda579b09cbbb69d776b2f4",
+    "content-hash": "4f9230e3e24a0992ad9bae2c3ee0458d",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -239,22 +239,22 @@
         },
         {
             "name": "laminas-api-tools/api-tools-admin-ui",
-            "version": "1.4.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas-api-tools/api-tools-admin-ui.git",
-                "reference": "f6e89e0a0b65c2e908b5d6abab9c88d38d124b18"
+                "reference": "e77c5b1295400d8695f26c484a338bafdf1668ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas-api-tools/api-tools-admin-ui/zipball/f6e89e0a0b65c2e908b5d6abab9c88d38d124b18",
-                "reference": "f6e89e0a0b65c2e908b5d6abab9c88d38d124b18",
+                "url": "https://api.github.com/repos/laminas-api-tools/api-tools-admin-ui/zipball/e77c5b1295400d8695f26c484a338bafdf1668ab",
+                "reference": "e77c5b1295400d8695f26c484a338bafdf1668ab",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-view": "^2.8.1",
                 "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
             "replace": {
                 "zfcampus/zf-apigility-admin-ui": "^1.3.13"
@@ -298,7 +298,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-06-09T14:04:35+00:00"
+            "time": "2022-06-07T13:37:05+00:00"
         },
         {
             "name": "laminas-api-tools/api-tools-api-problem",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes/no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Use `laminas-api-tools/api-tools-admin-ui` new major