### PR TITLE
fixing wrong input filter selection

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1696,7 +1696,7 @@ return [
             'ZF\Apigility\Admin\InputFilter\RestService\PATCH'                   => RestPatchInputFilter::class,
             'ZF\Apigility\Admin\InputFilter\RestService\POST'                    => RestPostInputFilter::class,
             'ZF\Apigility\Admin\InputFilter\RpcService\PATCH'                    => RpcPatchInputFilter::class,
-            'ZF\Apigility\Admin\InputFilter\RpcService\POST'                     => RpcPatchInputFilter::class,
+            'ZF\Apigility\Admin\InputFilter\RpcService\POST'                     => RpcPostInputFilter::class,
             'ZF\Apigility\Admin\InputFilter\Version'                             => VersionInputFilter::class,
 
             // Legacy Zend Framework aliases v2
@@ -1712,7 +1712,7 @@ return [
             'ZF\Apigility\Admin\InputFilter\PatchInputFilter'                    => RestPatchInputFilter::class,
             'ZF\Apigility\Admin\InputFilter\PostInputFilter'                     => RestPostInputFilter::class,
             'ZF\Apigility\Admin\InputFilter\RpcService\PatchInputFilter'         => RpcPatchInputFilter::class,
-            'ZF\Apigility\Admin\InputFilter\RpcService\PostInputFilter'          => RpcPatchInputFilter::class,
+            'ZF\Apigility\Admin\InputFilter\RpcService\PostInputFilter'          => RpcPostInputFilter::class,
             'ZF\Apigility\Admin\InputFilter\VersionInputFilter'                  => VersionInputFilter::class,
             'ZF\Apigility\Admin\InputFilter\InputFilter'                         => InputFilterInputFilter::class,
         ],


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR fixes wrong input filters for RPC calls. Currently, in 2.1.0 it isn't possible to create a new RPC service, as described in https://github.com/laminas-api-tools/api-tools-admin/issues/81

Currently, PATCH Input filters are applied to RPC Post calls in certain cases.